### PR TITLE
Upgrade to CMocka 1.1.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ include(cmake/FetchCMocka.cmake)
 
 add_executable(CMockaExample main.c)
 target_compile_features(CMockaExample PRIVATE c_std_99)
-target_link_libraries(CMockaExample PRIVATE cmocka-static)
+target_link_libraries(CMockaExample PRIVATE cmocka)
 
 enable_testing()
 add_test(NAME CMockaExample COMMAND CMockaExample)

--- a/cmake/FetchCMocka.cmake
+++ b/cmake/FetchCMocka.cmake
@@ -22,11 +22,11 @@ include(FetchContent)
 FetchContent_Declare(
   cmocka
   GIT_REPOSITORY https://git.cryptomilk.org/projects/cmocka.git
-  GIT_TAG        cmocka-1.1.5
+  GIT_TAG        cmocka-1.1.8
   GIT_SHALLOW    1
 )
 
-set(WITH_STATIC_LIB ON CACHE BOOL "CMocka: Build with a static library" FORCE)
+set(BUILD_SHARED_LIBS OFF CACHE BOOL "CMocka: Build shared libraries" FORCE)
 set(WITH_CMOCKERY_SUPPORT OFF CACHE BOOL "CMocka: Install a cmockery header" FORCE)
 set(WITH_EXAMPLES OFF CACHE BOOL "CMocka: Build examples" FORCE)
 set(UNIT_TESTING OFF CACHE BOOL "CMocka: Build with unit testing" FORCE)


### PR DESCRIPTION
Upgrade to v1.1.8 where they've renamed both the option to build a static lib and the name of library target